### PR TITLE
Use class_addMethod to add the method to DVTLayoutManager when possible.

### DIFF
--- a/ThinStrokes/ThinStrokes.m
+++ b/ThinStrokes/ThinStrokes.m
@@ -45,7 +45,10 @@ extern int CGContextGetFontSmoothingStyle(CGContextRef);
         
         CGContextSetFontSmoothingStyle(ctx, savedFontSmoothingStyle);
     });
-    method_setImplementation(showCGGlyphsMethod, newIMP);
+    BOOL didAdd = class_addMethod(DVTLayoutManager, showCGGlyphsSEL, newIMP, method_getTypeEncoding(showCGGlyphsMethod));
+    if(!didAdd) {
+        method_setImplementation(showCGGlyphsMethod, newIMP);
+    }
 }
 
 @end


### PR DESCRIPTION
This avoids overriding the method on NSLayoutManager if DVTLayoutManager doesn't implement it, which as of Xcode 7.2 it does not.
